### PR TITLE
Add support for toggling thinking mode

### DIFF
--- a/src/nodes/OllamaChatNode.ts
+++ b/src/nodes/OllamaChatNode.ts
@@ -263,6 +263,15 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
         });
       }
 
+      if (data.useThinkInput) {
+        inputs.push({
+          id: "think" as PortId,
+          dataType: "string",
+          title: "Think",
+          description: "Enable or disable thinking for models that support it.",
+        });
+      }
+
       if (data.useSeedInput) {
         inputs.push({
           id: "seed" as PortId,
@@ -355,15 +364,6 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
         });
       }
 
-      if (data.useThinkInput) {
-        inputs.push({
-          id: "think" as PortId,
-          dataType: "string",
-          title: "Think",
-          description: "Enable or disable thinking for models that support it.",
-        });
-      }
-
       return inputs;
     },
 
@@ -434,6 +434,20 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
           helperMessage:
             "The temperature of the model. Increasing the temperature will make the model answer more creatively. (Default: 0.8)",
           allowEmpty: true,
+        },
+        {
+          type: "dropdown",
+          dataKey: "think",
+          useInputToggleDataKey: "useThinkInput",
+          label: "Thinking",
+          options: [
+            { value: "", label: "Unset" },
+            { value: "true", label: "Enable" },
+            { value: "false", label: "Disable" },
+          ],
+          defaultValue: "",
+          helperMessage:
+            "Enable or disable thinking for models that support it. When enabled, the model's thinking process will be available in the thinking output.",
         },
         {
           type: "group",
@@ -617,20 +631,6 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
               keyPlaceholder: "Header Name",
               valuePlaceholder: "Header Value",
               helperMessage: "Additional headers to send to the API.",
-            },
-            {
-              type: "dropdown",
-              dataKey: "think",
-              useInputToggleDataKey: "useThinkInput",
-              label: "Thinking",
-              options: [
-                { value: "", label: "Unset" },
-                { value: "true", label: "Enable" },
-                { value: "false", label: "Disable" },
-              ],
-              defaultValue: "",
-              helperMessage:
-                "Enable or disable thinking for models that support it. When enabled, the model's thinking process will be available in the thinking output.",
             },
           ],
         },

--- a/src/nodes/OllamaChatNode.ts
+++ b/src/nodes/OllamaChatNode.ts
@@ -81,6 +81,9 @@ export type OllamaChatNodeData = {
 
   headers?: { key: string; value: string }[];
   useHeadersInput?: boolean;
+
+  think?: "" | "true" | "false";
+  useThinkInput?: boolean;
 };
 
 export type OllamaChatNode = ChartNode<"ollamaChat2", OllamaChatNodeData>;
@@ -92,6 +95,7 @@ type OllamaStreamingContentResponse = {
   message: {
     role: string;
     content: string;
+    thinking?: string;
   };
 };
 
@@ -101,6 +105,7 @@ type OllamaStreamingFinalResponse = {
   message: {
     role: string;
     content: string;
+    thinking?: string;
   };
   done: true;
   total_duration: number;
@@ -127,6 +132,8 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
           jsonMode: false,
           advancedOutputs: false,
           stop: "",
+          think: "",
+          useThinkInput: false,
         },
         title: "Ollama Chat",
         type: "ollamaChat2",
@@ -341,10 +348,19 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
 
       if (data.useHeadersInput) {
         inputs.push({
-          dataType: 'object',
-          id: 'headers' as PortId,
-          title: 'Headers',
-          description: 'Additional headers to send to the API.',
+          dataType: "object",
+          id: "headers" as PortId,
+          title: "Headers",
+          description: "Additional headers to send to the API.",
+        });
+      }
+
+      if (data.useThinkInput) {
+        inputs.push({
+          id: "think" as PortId,
+          dataType: "string",
+          title: "Think",
+          description: "Enable or disable thinking for models that support it.",
         });
       }
 
@@ -358,6 +374,13 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
           dataType: "string",
           title: "Output",
           description: "The output from Ollama.",
+        },
+        {
+          id: "thinking" as PortId,
+          dataType: "string",
+          title: "Thinking",
+          description:
+            "The thinking process from Ollama (only available for models that support thinking).",
         },
         {
           id: "messages-sent" as PortId,
@@ -593,8 +616,21 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
               useInputToggleDataKey: "useHeadersInput",
               keyPlaceholder: "Header Name",
               valuePlaceholder: "Header Value",
+              helperMessage: "Additional headers to send to the API.",
+            },
+            {
+              type: "dropdown",
+              dataKey: "think",
+              useInputToggleDataKey: "useThinkInput",
+              label: "Thinking",
+              options: [
+                { value: "", label: "Unset" },
+                { value: "true", label: "Enable" },
+                { value: "false", label: "Disable" },
+              ],
+              defaultValue: "",
               helperMessage:
-                "Additional headers to send to the API.",
+                "Enable or disable thinking for models that support it. When enabled, the model's thinking process will be available in the thinking output.",
             },
           ],
         },
@@ -762,7 +798,21 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
         format?: string;
         options: any;
         stream: boolean;
+        think?: boolean;
       };
+
+      const thinkInput = rivet.getInputOrData(
+        data,
+        inputData,
+        "think",
+        "string",
+      );
+      const think =
+        thinkInput === "true"
+          ? true
+          : thinkInput === "false"
+            ? false
+            : undefined;
 
       const requestBody: RequestBodyType = {
         model,
@@ -770,6 +820,10 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
         stream: true,
         options: parameters,
       };
+
+      if (think !== undefined) {
+        requestBody.think = think;
+      }
 
       if (data.jsonMode === true) {
         requestBody.format = "json";
@@ -803,7 +857,7 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
             {} as Record<string, string>,
           );
         }
-        
+
         Object.assign(headers, additionalHeaders);
 
         apiResponse = await fetch(`${host}/api/chat`, {
@@ -832,6 +886,7 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
 
       let streamingResponseText = "";
       let llmResponseText = "";
+      let thinkingText = "";
 
       let finalResponse: OllamaStreamingFinalResponse | undefined;
 
@@ -858,12 +913,20 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
               }
 
               if (!json.done) {
-                if (llmResponseText === "") {
-                  llmResponseText += (
-                    json.message.content as string
-                  ).trimStart();
-                } else {
-                  llmResponseText += json.message.content;
+                // Handle thinking content
+                if (json.message.thinking) {
+                  thinkingText += json.message.thinking;
+                }
+
+                // Handle regular content
+                if (json.message.content) {
+                  if (llmResponseText === "") {
+                    llmResponseText += (
+                      json.message.content as string
+                    ).trimStart();
+                  } else {
+                    llmResponseText += json.message.content;
+                  }
                 }
               } else {
                 finalResponse = json;
@@ -878,6 +941,11 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
           outputs["output" as PortId] = {
             type: "string",
             value: llmResponseText,
+          };
+
+          outputs["thinking" as PortId] = {
+            type: "string",
+            value: thinkingText,
           };
 
           context.onPartialOutputs?.(outputs);
@@ -903,6 +971,11 @@ export const ollamaChat2 = (rivet: typeof Rivet) => {
             function_call: undefined,
           },
         ],
+      };
+
+      outputs["thinking" as PortId] = {
+        type: "string",
+        value: thinkingText,
       };
 
       return outputs;

--- a/src/nodes/OllamaGenerateNode.ts
+++ b/src/nodes/OllamaGenerateNode.ts
@@ -268,6 +268,15 @@ export const ollamaChat = (rivet: typeof Rivet) => {
         });
       }
 
+      if (data.useThinkInput) {
+        inputs.push({
+          id: "think" as PortId,
+          dataType: "string",
+          title: "Think",
+          description: "Enable or disable thinking for models that support it.",
+        });
+      }
+
       if (data.useSeedInput) {
         inputs.push({
           id: "seed" as PortId,
@@ -357,15 +366,6 @@ export const ollamaChat = (rivet: typeof Rivet) => {
           id: 'headers' as PortId,
           title: 'Headers',
           description: 'Additional headers to send to the API.',
-        });
-      }
-
-      if (data.useThinkInput) {
-        inputs.push({
-          id: "think" as PortId,
-          dataType: "string",
-          title: "Think",
-          description: "Enable or disable thinking for models that support it.",
         });
       }
 
@@ -521,6 +521,20 @@ export const ollamaChat = (rivet: typeof Rivet) => {
           label: "Advanced Outputs",
           helperMessage:
             "Add additional outputs with detailed information about the Ollama execution.",
+        },
+        {
+          type: "dropdown",
+          dataKey: "think",
+          useInputToggleDataKey: "useThinkInput",
+          label: "Thinking",
+          options: [
+            { value: "", label: "Unset" },
+            { value: "true", label: "Enable" },
+            { value: "false", label: "Disable" },
+          ],
+          defaultValue: "",
+          helperMessage:
+            "Enable or disable thinking for models that support it. When enabled, the model's thinking process will be available in the thinking output.",
         },
         {
           type: "group",
@@ -714,20 +728,6 @@ export const ollamaChat = (rivet: typeof Rivet) => {
               valuePlaceholder: "Header Value",
               helperMessage:
                 "Additional headers to send to the API.",
-            },
-            {
-              type: "dropdown",
-              dataKey: "think",
-              useInputToggleDataKey: "useThinkInput",
-              label: "Thinking",
-              options: [
-                { value: "", label: "Unset" },
-                { value: "true", label: "Enable" },
-                { value: "false", label: "Disable" },
-              ],
-              defaultValue: "",
-              helperMessage:
-                "Enable or disable thinking for models that support it. When enabled, the model's thinking process will be available in the thinking output.",
             },
           ],
         },


### PR DESCRIPTION
fixes https://github.com/abrenneke/rivet-plugin-ollama/issues/13. More setting thinking flags at https://ollama.com/blog/thinking

OllamaChat/OllamaGenerate node now has a Thinking dropdown. Since undefined/true/false are treated differently by Ollama, I have made it a dropdown instead of a boolean toggle.

![image](https://github.com/user-attachments/assets/4a9f0495-6fe0-4dbd-98e2-7ee364847237)

When set to "Unset".

![image](https://github.com/user-attachments/assets/b620f5eb-4d0e-4310-8779-8511e7c2e97e)

When set to "Enabled"

![image](https://github.com/user-attachments/assets/2d9dbdec-fae1-4aa4-b2bb-061c108068ad)

When set to "Disabled"

![image](https://github.com/user-attachments/assets/e8f62ac8-9fc9-4f6a-a9a2-33b3e0585685)
